### PR TITLE
Allow using postgrex 0.16

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule Commanded.Middleware.Auditing.Mixfile do
       {:elixir_uuid, "~> 1.2"},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:jason, "~> 1.1"},
-      {:postgrex, "~> 0.15.0"}
+      {:postgrex, "~> 0.15"}
     ]
   end
 


### PR DESCRIPTION
Specify the [same postgrex requirement as commanded/eventstore](https://github.com/commanded/eventstore/blob/9883f4ae9cb8bbde3e8c905e1dc6f66fac746a56/mix.exs#L45) to allow using postgrex 0.16.